### PR TITLE
[CG LICENSE] add test suite license

### DIFF
--- a/CG-LICENSE.md
+++ b/CG-LICENSE.md
@@ -5,3 +5,6 @@ under the
 Contributions to Specifications are made under the
 [W3C CLA](https://www.w3.org/community/about/agreements/cla/).
 
+Contributions to Test Suites are made under the
+[W3C 3-clause BSD License](https://www.w3.org/Consortium/Legal/2008/03-bsd-license.html)
+


### PR DESCRIPTION
[POLICIES FOR CONTRIBUTION OF TEST CASES TO W3C](https://www.w3.org/2004/10/27-testcases) links to [Licenses for W3C Test Suites](https://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright) which contains 2 licenses, one a W3C branded one for WGs and the other [ 3-clause BSD License ](https://www.w3.org/Consortium/Legal/2008/03-bsd-license.html).  For CG-LICENSE.md, just including that directly rather than having to follow the WG only references.  The end result is the same license available for WG test suites, which should make it easy to do the test suites in W3C's test repository or to move it there later when the work moves to a WG.